### PR TITLE
Add support for aws iam provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,20 @@ From Environment
     S3_SECRET_KEY
     S3_PREFIX
     S3_INSECURE
+
+
+AWS IAM Provider Example
+
+Caddyfile Example
+
+    # Global Config
+
+    {
+        storage s3 {
+            host "Host"
+            bucket "Bucket"
+            use_iam_provider: true,
+            prefix "ssl"
+            insecure false #disables SSL if true
+        }
+    }

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Caddyfile Example
         storage s3 {
             host "Host"
             bucket "Bucket"
-            use_iam_provider: true,
+            use_iam_provider true
             prefix "ssl"
             insecure false #disables SSL if true
         }


### PR DESCRIPTION
give one the opportunity to use aws ecs task roles to give a task access to an s3 bucket.
This works without giving passwords in advance.