### PR TITLE
fix: list file with prefix properly for compatibility with `caddy storage` commands

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -216,14 +216,14 @@ func (s3 S3) List(ctx context.Context, prefix string, recursive bool) ([]string,
 	defer cancel()
 
 	objects := s3.Client.ListObjects(ctx, s3.Bucket, minio.ListObjectsOptions{
-		Prefix:    prefix,
+		Prefix:    s3.KeyPrefix(prefix),
 		Recursive: recursive,
 	})
 
 	keys := make([]string, len(objects))
 
 	for object := range objects {
-		keys = append(keys, object.Key)
+		keys = append(keys, s3.CutKeyPrefix(object.Key))
 	}
 
 	return keys, nil
@@ -252,6 +252,10 @@ func (s3 S3) Stat(ctx context.Context, key string) (certmagic.KeyInfo, error) {
 
 func (s3 S3) KeyPrefix(key string) string {
 	return path.Join(s3.Prefix, key)
+}
+func (s3 S3) CutKeyPrefix(key string) string {
+	cutted, _ := strings.CutPrefix(key, s3.Prefix)
+	return cutted
 }
 
 func (s3 S3) String() string {


### PR DESCRIPTION
Recently caddy cli introduced a new `caddy storage` command with exports/imports the files in storage.

When I have a prefix of `caddy/store/`, using `caddy storage export`, would got:

```
> caddy storage export --config Caddyfile -output ./exported.tar
2024/09/19 06:38:59.807 INFO    using config from file  {"file": "Caddyfile"}
2024/09/19 06:38:59.807 INFO    adapted config to JSON  {"adapter": "caddyfile"}
2024/09/19 06:38:59.807 WARN    Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies      {"adapter": "caddyfile", "file": "Caddyfile", "line": 1}
2024-09-19T14:38:59.807+0800    INFO    certmagic-s3@v0.0.0-20231226052753-62a3ac98984d/s3.go:124 use secret_key and access_id for credentials
2024-09-19T14:39:01.498+0800    ERROR   certmagic-s3@v0.0.0-20231226052753-62a3ac98984d/s3.go:238 Stat key: caddy/store/caddy/store/acme/acme-v02.api.letsencrypt.org-directory/users/artiga033@hotmail.com/artiga033.json, error: The specified key does not exist.
github.com/ss098/certmagic-s3.S3.Stat
        github.com/ss098/certmagic-s3@v0.0.0-20231226052753-62a3ac98984d/s3.go:238
github.com/caddyserver/caddy/v2/cmd.cmdExportStorage
        github.com/caddyserver/caddy/v2@v2.8.4/cmd/storagefuncs.go:191
```

So it seems when listing files the prefix is not stripped and when reading it's prepended again.

This fix removes the prefix for listing results as it's added back when doing other operations after all.

I have tested it for `caddy run` and `caddy storage export` for a single case, but still not sure about if it breaks anything.