### PR TITLE
Fix the go routine leak in get object call

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -222,6 +222,8 @@ func (s3 *S3) Load(ctx context.Context, key string) ([]byte, error) {
 		return nil, err
 	}
 
+	defer object.Close()
+	
 	return io.ReadAll(object)
 }
 


### PR DESCRIPTION
Fixes a memory leak related to reader objects that are not being closed.

Found due to a growing number of goroutines running in my caddy server and tracked the leak to the minio GetObject function which lead me to this issue https://github.com/minio/minio-go/issues/1508

Let me know if there is anything else I should include in this change