### PR TITLE
Add support for optional port in host input

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/url"
 	"os"
 	"path"
@@ -297,6 +298,10 @@ func (s3 *S3) String() string {
 }
 
 func validateHost(h string) error {
+	x, _, err := net.SplitHostPort(h)
+	if err == nil && x != "" {
+		h = x
+	}
 	u, err := url.Parse(h)
 	if err != nil {
 		return fmt.Errorf("invalid host: must be a hostname: %w", err)


### PR DESCRIPTION
Add support for optional port in host input

This PR introduces support for specifying an optional port in the host[:port] format.

What’s changed:
	•	Parses the input using net.SplitHostPort to allow hostnames or IP addresses with an optional port.
	•	Host validation logic remains unchanged (e.g. domain/IP/localhost handling).

Examples of valid input:
	•	localhost
	•	localhost:8080
	•	example.com
	•	example.com:443
	•	127.0.0.1:3000

This change enables more flexibility in configuration while keeping host validation logic intact.